### PR TITLE
Add PackageProjectUrl to csproj

### DIFF
--- a/Blend.RobotsTxt/Blend.RobotsTxt.csproj
+++ b/Blend.RobotsTxt/Blend.RobotsTxt.csproj
@@ -16,6 +16,7 @@
   <PropertyGroup>
     <PackageId>Our.Umbraco.Blend.RobotsTxt</PackageId>
     <PackageTags>umbraco plugin package robots blend umbraco-marketplace</PackageTags>
+    <PackageProjectUrl>https://github.com/blendinteractive/Blend.RobotsTxt.Umbraco</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/blendinteractive/Blend.RobotsTxt.Umbraco</RepositoryUrl>


### PR DESCRIPTION
Hi - I noticed we weren't picking up your additional information for this packages listing on the Umbraco marketplace.  It looks to be because the NuGet package doesn't include a "project URL", which we rely on to follow and find the `umbraco-marketplace.json` file that you have created.

This PR adds that, which, one updated,  which will at ensure your package is listed under the appropriate category and brings in the extra information you have provided.